### PR TITLE
Fix checkout button logic

### DIFF
--- a/src/test/java/org.example/pages/CheckoutPageActions.java
+++ b/src/test/java/org.example/pages/CheckoutPageActions.java
@@ -19,9 +19,9 @@ public class CheckoutPageActions {
     }
 
     public void proceedToCheckout() {
-        driver.findElement(locators.checkoutButton).click();
         // Wait until the "Proceed to checkout" button is clickable
-        WebElement checkoutButton = wait.until(ExpectedConditions.elementToBeClickable(locators.checkoutButton));
+        WebElement checkoutButton = wait.until(
+                ExpectedConditions.elementToBeClickable(locators.checkoutButton));
         checkoutButton.click();
     }
 


### PR DESCRIPTION
## Summary
- avoid clicking the checkout button twice in `CheckoutPageActions`

## Testing
- `javac src/test/java/org.example/pages/CheckoutPageActions.java` *(fails: package org.openqa.selenium does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68508852e3648324aa1be6076b5b8644